### PR TITLE
Re-register `translate` executable in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/75lb/linguist",
   "main": "./index.mjs",
   "exports": "./index.mjs",
+  "bin": {
+    "translate": "bin/cli.mjs"
+  },
   "keywords": [
     "language",
     "translation"


### PR DESCRIPTION
Version 0.2.0 removed the `bin` section of `package.json` here: https://github.com/75lb/linguist/commit/c980128bb571d567de96e99ee55feb101284bff3#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-L13

This leads to the following error when running the script:

```
$ translate --from en --to de "hello world"
'translate' is not recognized as an internal or external command,
operable program or batch file.
```

This PR re-adds the `bin` key to `package.json`.